### PR TITLE
Fix build on linux

### DIFF
--- a/MyApp.sln
+++ b/MyApp.sln
@@ -5,11 +5,11 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{058D16DF-B25A-4FF5-A87B-3C97F82509AD}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Client", "src\Client\Client.fsproj", "{01FD8181-E691-490F-89F7-4C5ACD617618}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Client", "src\client\Client.fsproj", "{01FD8181-E691-490F-89F7-4C5ACD617618}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Shared", "src\Shared\Shared.fsproj", "{7003EEBA-8A83-49A3-A140-2E5B1316024A}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Shared", "src\shared\Shared.fsproj", "{7003EEBA-8A83-49A3-A140-2E5B1316024A}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Server", "src\Server\Server.fsproj", "{F8769975-B78E-4C79-A897-3FE60A8CC0C9}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Server", "src\server\Server.fsproj", "{F8769975-B78E-4C79-A897-3FE60A8CC0C9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/build.fsproj
+++ b/build.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/Build.fs
+++ b/build/Build.fs
@@ -190,7 +190,6 @@ Target.create "PreBuild" (fun _ ->
         fun () -> bld clientDir
     |]
     |> Seq.iter (fun act -> act())
-//    |> Array.Parallel.iter (fun act -> act())
 )
 
 Target.create "Bundle" (fun _ ->

--- a/build/Build.fs
+++ b/build/Build.fs
@@ -189,7 +189,8 @@ Target.create "PreBuild" (fun _ ->
         fun () -> bld serverDir
         fun () -> bld clientDir
     |]
-    |> Array.Parallel.iter (fun act -> act())
+    |> Seq.iter (fun act -> act())
+//    |> Array.Parallel.iter (fun act -> act())
 )
 
 Target.create "Bundle" (fun _ ->

--- a/src/client/Client.fsproj
+++ b/src/client/Client.fsproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Shared\Shared.fsproj" />
+    <ProjectReference Include="..\shared\Shared.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/src/server/Server.fsproj
+++ b/src/server/Server.fsproj
@@ -13,6 +13,6 @@
     <PackageReference Include="WebSharper.AspNetCore" Version="7.0.3.348-beta2" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Shared\Shared.fsproj" />
+    <ProjectReference Include="..\shared\Shared.fsproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This wouldn't build on linux because of a few issues:

1. The client/shared/server folder names are lowercase but when being referenced they are in Titlecase - this doesn't work on case sensitive filesystems.
2. Building server and client in parallel didn't work because Shared.pdb was being locked.
3. Upgraded to .NET 8 as I don't have .NET 7 SDK installed and it's out of date.